### PR TITLE
feature: updated ESLint to cover all rules enforced by JSHint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,13 +12,18 @@
 
 	"rules" : {
 
+		// Possible Errors
+		"no-empty" : 2,
+
 		// Best Practices
 		"complexity"            : [ 1, 10 ],
 		"consistent-return"     : 2,
 		"curly"                 : [ 2, "all" ],
 		"dot-notation"          : 2,
 		"eqeqeq"                : 2,
+		"guard-for-in"          : 2,
 		"no-alert"              : 2,
+		"no-caller"             : 2,
 		"no-else-return"        : 2,
 		"no-eq-null"            : 2,
 		"no-eval"               : 2,
@@ -51,7 +56,7 @@
 		"no-shadow-restricted-names" : 2,
 		"no-undef"                   : 2,
 		"no-undef-init"              : 2,
-		"no-unused-vars"             : 0,
+		"no-unused-vars"             : 2,
 		"no-use-before-define"       : 2,
 
 		// Node.js
@@ -61,30 +66,36 @@
 		"no-process-exit"     : 2,
 
 		// Stylistic Issues
-		"brace-style"             : [ 2, "1tbs" ],
-		"camelcase"               : 2,
-		"consistent-this"         : [ 0, "self" ],
-		"func-names"              : 1,
-		"comma-spacing"           : [ 2, { "before" : false, "after" : true } ],
-		"key-spacing"             : [ 2, { "beforeColon" : true, "afterColon" : true, "align" : "colon" } ],
-		"max-nested-callbacks"    : [ 1, 4 ],
-		"new-cap"                 : 2,
-		"new-parens"              : 2,
-		"no-array-constructor"    : 2,
-		"no-nested-ternary"       : 2,
-		"no-new-object"           : 2,
-		"no-space-before-semi"    : 2,
-		"no-spaced-func"          : 2,
-		"no-ternary"              : 2,
-		"no-underscore-dangle"    : 2,
-		"no-wrap-func"            : 2,
-		"one-var"                 : 0,
-		"quote-props"             : 2,
-		"quotes"                  : [ 2, "single", "avoid-escape" ],
-		"semi"                    : 2,
-		"space-in-brackets"       : [ 2, "always" ],
-		"space-infix-ops"         : 2,
-		"space-return-throw-case" : 2,
-		"space-unary-ops"         : [ 2, { "words" : true, "nonwords" : false } ]
+		"brace-style"              : [ 2, "1tbs" ],
+		"camelcase"                : 2,
+		"consistent-this"          : [ 0, "self" ],
+		"func-names"               : 1,
+		"comma-spacing"            : [ 2, { "before" : false, "after" : true } ],
+		"key-spacing"              : [ 2, { "beforeColon" : true, "afterColon" : true, "align" : "colon" } ],
+		"max-nested-callbacks"     : [ 1, 4 ],
+		"new-cap"                  : 2,
+		"new-parens"               : 2,
+		"no-array-constructor"     : 2,
+		"no-mixed-spaces-and-tabs" : 2,
+		"no-nested-ternary"        : 2,
+		"no-new-object"            : 2,
+		"no-space-before-semi"     : 2,
+		"no-spaced-func"           : 2,
+		"no-ternary"               : 2,
+		"no-trailing-spaces"       : 2,
+		"no-underscore-dangle"     : 2,
+		"no-wrap-func"             : 2,
+		"one-var"                  : 0,
+		"quote-props"              : 2,
+		"quotes"                   : [ 2, "single", "avoid-escape" ],
+		"semi"                     : 2,
+		"space-in-brackets"        : [ 2, "always" ],
+		"space-infix-ops"          : 2,
+		"space-return-throw-case"  : 2,
+		"space-unary-ops"          : [ 2, { "words" : true, "nonwords" : false } ],
+
+		// Legacy
+		"no-bitwise" : 2,
+		"max-params" : [ 2, 8 ],
 	}
 }

--- a/.eslintrc-test
+++ b/.eslintrc-test
@@ -30,13 +30,18 @@
 
 	"rules" : {
 
+		// Possible Errors
+		"no-empty" : 2,
+
 		// Best Practices
 		"complexity"            : [ 1, 10 ],
 		"consistent-return"     : 2,
 		"curly"                 : [ 2, "all" ],
 		"dot-notation"          : 2,
 		"eqeqeq"                : 2,
+		"guard-for-in"          : 2,
 		"no-alert"              : 2,
+		"no-caller"             : 2,
 		"no-else-return"        : 2,
 		"no-eq-null"            : 2,
 		"no-eval"               : 2,
@@ -69,7 +74,7 @@
 		"no-shadow-restricted-names" : 2,
 		"no-undef"                   : 2,
 		"no-undef-init"              : 2,
-		"no-unused-vars"             : 0,
+		"no-unused-vars"             : 2,
 		"no-use-before-define"       : 2,
 
 		// Node.js
@@ -79,30 +84,36 @@
 		"no-process-exit"     : 2,
 
 		// Stylistic Issues
-		"brace-style"             : [ 2, "1tbs" ],
-		"camelcase"               : 2,
-		"consistent-this"         : [ 0, "self" ],
-		"func-names"              : 0,
-		"comma-spacing"           : [ 2, { "before" : false, "after" : true } ],
-		"key-spacing"             : [ 2, { "beforeColon" : true, "afterColon" : true, "align" : "colon" } ],
-		"max-nested-callbacks"    : [ 1, 4 ],
-		"new-cap"                 : 2,
-		"new-parens"              : 2,
-		"no-array-constructor"    : 2,
-		"no-nested-ternary"       : 2,
-		"no-new-object"           : 2,
-		"no-space-before-semi"    : 2,
-		"no-spaced-func"          : 2,
-		"no-ternary"              : 2,
-		"no-underscore-dangle"    : 2,
-		"no-wrap-func"            : 2,
-		"one-var"                 : 0,
-		"quote-props"             : 2,
-		"quotes"                  : [ 2, "single", "avoid-escape" ],
-		"semi"                    : 2,
-		"space-in-brackets"       : [ 2, "always" ],
-		"space-infix-ops"         : 2,
-		"space-return-throw-case" : 2,
-		"space-unary-ops"         : [ 2, { "words" : true, "nonwords" : false } ]
+		"brace-style"              : [ 2, "1tbs" ],
+		"camelcase"                : 2,
+		"consistent-this"          : [ 0, "self" ],
+		"func-names"               : 0,
+		"comma-spacing"            : [ 2, { "before" : false, "after" : true } ],
+		"key-spacing"              : [ 2, { "beforeColon" : true, "afterColon" : true, "align" : "colon" } ],
+		"max-nested-callbacks"     : [ 1, 4 ],
+		"new-cap"                  : 2,
+		"new-parens"               : 2,
+		"no-array-constructor"     : 2,
+		"no-mixed-spaces-and-tabs" : 2,
+		"no-nested-ternary"        : 2,
+		"no-new-object"            : 2,
+		"no-space-before-semi"     : 2,
+		"no-spaced-func"           : 2,
+		"no-ternary"               : 2,
+		"no-trailing-spaces"       : 2,
+		"no-underscore-dangle"     : 2,
+		"no-wrap-func"             : 2,
+		"one-var"                  : 0,
+		"quote-props"              : 2,
+		"quotes"                   : [ 2, "single", "avoid-escape" ],
+		"semi"                     : 2,
+		"space-in-brackets"        : [ 2, "always" ],
+		"space-infix-ops"          : 2,
+		"space-return-throw-case"  : 2,
+		"space-unary-ops"          : [ 2, { "words" : true, "nonwords" : false } ],
+
+		// Legacy
+		"no-bitwise" : 2,
+		"max-params" : [ 2, 8 ],
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sinet-coding-conventions",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Coding conventions for School Improvement Network",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -23,10 +23,12 @@ The following three books are great reference for this topic. It is highly recom
 ## Setup / Configuration
 
 Using terminal, download the following linting and editor configuration files in your project directory:
-```
+```bash
 curl -O https://raw.githubusercontent.com/School-Improvement-Network/coding-conventions/master/.editorconfig
 curl -O https://raw.githubusercontent.com/School-Improvement-Network/coding-conventions/master/.eslintrc
 curl -O https://raw.githubusercontent.com/School-Improvement-Network/coding-conventions/master/.jscsrc
+# JSHint rules are deprecated, and will be removed in the next major release.
+# All previously configured JSHint rules are covered by ESLint.
 curl -O https://raw.githubusercontent.com/School-Improvement-Network/coding-conventions/master/.jshintrc
 ```
 


### PR DESCRIPTION
This allows to you just use ESLint and JSCS to cover all the rules. There is no
more need to have both ESLint and JSHint checked. Some of the rules already
existed for ESLint.

Below is a mapping of the JSHint rules and the ESLint rules that cover them.

- bitwise -> no-bitwise
- curly -> curly
- eqeqeq -> eqeqeq
- forin -> guard-for-in
- latedef -> no-use-before-define
- newcap -> new-cap
- noarg -> no-caller
- noempty -> no-empty
- undef -> no-undef and no-undef-init
- strict -> strict
- trailing -> no-trailing-spaces
- evil -> no-eval
- quotmark -> quotes
- node -> env
- browser -> env
- sub -> dot-notation
- smarttabs -> no-mixed-spaces-and-tabs
- camelcase -> camelcase
- maxparams -> max-params
- unused -> no-unused-vars